### PR TITLE
API: fix UnitGroupRoles

### DIFF
--- a/CompactRaidFrame/Dependence/API.lua
+++ b/CompactRaidFrame/Dependence/API.lua
@@ -468,11 +468,26 @@ function GetSpecializationRole(specIndex)
 end
 
 function UnitGroupRoles(unit)
-	if ( not LibGT ) then
-		return "NONE";
+	local role
+	-- For 3.3.5 roles are assigned only for LFG, so the API UnitGroupRolesAssigned works only for LFG
+	-- For LFG, do not need to use third-party methods to define a role that is not always defined correctly.
+	local isTank, isHealer, isDamage = UnitGroupRolesAssigned(unit)
+	if isTank then
+		role = "TANK"
+	elseif isHealer then
+		role = "HEALER"
+	elseif isDamage then
+		role = "DAMAGER"
+	else
+		-- It makes no sense to use third-party methods to define a role if the role of this class is only one.
+		local _,class = UnitClass(unit)
+		if class == "HUNTER" or class == "ROGUE" or class == "MAGE" or class == "WARLOCK" then
+			role = "DAMAGER"
+		elseif LibGT then
+			role = LibGTConvertRole[LibGT:GetUnitRole(unit)]
+		end
 	end
-
-	return LibGTConvertRole[LibGT:GetUnitRole(unit)] or "NONE"; 
+	return role or "NONE";
 end
 
 function UnitShouldDisplayName(unitToken)


### PR DESCRIPTION
Fix the wrong definition of the role for LFG:
![WoWScrnShot_062021_010453](https://user-images.githubusercontent.com/24303693/122669254-1e2d9b80-d1c5-11eb-8290-44c74657acd1.jpg)
This issue is most relevant at low levels of players.

In the LFG roles are assigned from the server, so do not need to use third-party role detection methods, just take the data from the server.
I also added an exception to detection the role for the classes, which in principle have only one role. It also does not make sense to detection the role for such classes.