### PR TITLE
inital hots display and class buff ignore for druid

### DIFF
--- a/CompactRaidFrame/CompactUnitFrame.lua
+++ b/CompactRaidFrame/CompactUnitFrame.lua
@@ -1224,6 +1224,15 @@ function isBlacklisted(spellName)
     if ( classIndex == 0) then
         return false;
     end
+    commonBuffBlacklist = {
+        --dungeon buffs
+        ["Luck of the Draw"] = true,
+    } 
+    for key,value in pairs(commonBuffBlacklist) do 
+        if ( spellName == key ) then
+            return true;
+        end
+    end
 
     -- blacklist spells for current class
     -- TODO: Add other classes

--- a/CompactRaidFrame/CompactUnitFrame.lua
+++ b/CompactRaidFrame/CompactUnitFrame.lua
@@ -1203,14 +1203,81 @@ end
 
 --Utility Functions
 function CompactUnitFrame_UtilShouldDisplayBuff(...)
-    local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura = ...;
+    local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId = ...;
     local hasCustom, alwaysShowMine, showForMySpec = SpellGetVisibilityInfo(spellId, UnitAffectingCombat("player") and "RAID_INCOMBAT" or "RAID_OUTOFCOMBAT");
+    local showAllClassBuffs = true;
+
+    if ( isBlacklisted(name) ) then
+        return false;
+    end
+
     if ( hasCustom ) then
-        return showForMySpec or (alwaysShowMine and (unitCaster == "player" or unitCaster == "pet" or unitCaster == "vehicle"));
+        return ( showForMySpec  ) or ( ( alwaysShowMine ) and (showAllClassBuffs or unitCaster == "player" or unitCaster == "pet" or unitCaster == "vehicle"));
     else
-        return (unitCaster == "player" or unitCaster == "pet" or unitCaster == "vehicle") and canApplyAura and not SpellIsSelfBuff(spellId);
+        return (( alwaysShowMine ) or unitCaster == "player" or unitCaster == "pet" or unitCaster == "vehicle") and not SpellIsSelfBuff(spellId);
     end
 end
+
+function isBlacklisted(spellName)
+    local _, class, classIndex = UnitClass("player"); 
+
+    if ( classIndex == 0) then
+        return false;
+    end
+
+    -- blacklist spells for current class
+    if ( class == "WARRIOR") then
+        return true;
+    elseif ( class == "PALADIN") then
+        return true;
+    elseif ( class == "HUNTER") then
+        return true;
+    elseif ( class == "ROGUE") then
+        return true;
+    elseif ( class == "PRIEST") then
+        return true;
+    elseif ( class == "DEATHKNIGHT") then
+        return true;
+    elseif ( class == "SHAMAN") then
+        return true;
+    elseif ( class == "MAGE") then
+        return true;
+    elseif ( class == "WARLOCK") then
+        return true;
+    elseif ( class == "SHAMAN") then
+        return true;
+    elseif ( class == "DRUID" ) then 
+        classBuffInfo = {
+            --class buffs
+            ["Mark of the Wild"] = true,
+            ["Gift of the Wild"] = true,
+            ["Thorns"] = true,
+
+
+            --forms
+            ["Aquatic Form"] = true,
+            ["Bear Form"] = true,
+            ["Dire Bear Form"] = true,
+            ["Flight Form"] = true,
+            ["Travel Form"] = true,
+            ["Swift Flight Form"] = true,
+            ["Cat Form"] = true,
+            ["Moonkin Form"] = true,
+            ["Tree of Life"] = true,
+
+                --stances
+                ["Prowl"] = true,
+                ["Track Humanoids"] = true,
+        } 
+        for key,value in pairs(classBuffInfo) do 
+            if ( spellName == key ) then
+                return true;
+            end
+        end
+    end 
+    return false;
+end
+
 
 function CompactUnitFrame_HideAllBuffs(frame, startingIndex)
     if frame.buffFrames then

--- a/CompactRaidFrame/CompactUnitFrame.lua
+++ b/CompactRaidFrame/CompactUnitFrame.lua
@@ -1226,26 +1226,27 @@ function isBlacklisted(spellName)
     end
 
     -- blacklist spells for current class
+    -- TODO: Add other classes
     if ( class == "WARRIOR") then
-        return true;
+        return false;
     elseif ( class == "PALADIN") then
-        return true;
+        return false;
     elseif ( class == "HUNTER") then
-        return true;
+        return false;
     elseif ( class == "ROGUE") then
-        return true;
+        return false;
     elseif ( class == "PRIEST") then
-        return true;
+        return false;
     elseif ( class == "DEATHKNIGHT") then
-        return true;
+        return false;
     elseif ( class == "SHAMAN") then
-        return true;
+        return false;
     elseif ( class == "MAGE") then
-        return true;
+        return false;
     elseif ( class == "WARLOCK") then
-        return true;
+        return false;
     elseif ( class == "SHAMAN") then
-        return true;
+        return false;
     elseif ( class == "DRUID" ) then 
         classBuffInfo = {
             --class buffs


### PR DESCRIPTION
# Description

The problem I had was that no `Heal over Time` buffs were displayed. This is especially annoying as heal. Furthermore irrelevant buffs like druid forms were displayed. 

The group and raidframes representation I use is `Keep Groups Together` as shown in the reference image


![example(1)](https://user-images.githubusercontent.com/24325735/147425411-dc64073b-26d0-430b-9ef3-86ec940c7119.jpg)





# Fixes  (no issue yet)

No display of buffs is specified in the blacklist. The blacklist currently is hardcoded and only a blacklist for druids is provided.
Display of HOTS 


## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

This currently has only been tested by hand for 3 spells. There should be more testcases.

**Test Configuration**:

Addon Configuration: 

![example_1](https://user-images.githubusercontent.com/24325735/147425072-80eaf02b-8767-40d0-8f23-1cff5bad7d14.jpg)

Environment: 
* Synergie WoW Private Server
* Lots of addons activated. e.g. Weakauras, kkthnxUI 
